### PR TITLE
Fix for multi branch deployment on the same host

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,6 +16,7 @@ RUN echo "" > /tmp/openssl.cnf
 
 RUN npm install
 
-EXPOSE 3001
+# Disable, needs `--expose` during `docker run` to prevent collisions
+# EXPOSE 3001
 
 CMD ["npm", "run", "serve"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       context: ./api/
       dockerfile: Dockerfile
     ports:
-      - "${API_PORT:-3001}:3001"
+      - "${OUTSIDE_API_PORT:-3001}:3001"
     environment:
       - NODE_ENV=${NODE_ENV:-development}
       - MONGO_URI=${MONGO_URI:-mongodb://xahau-docproof-db:27017/xahau-docproof}
@@ -37,7 +37,7 @@ services:
       context: ./xapp/
       dockerfile: Dockerfile
     ports:
-      - "${XAPP_PORT:-3000}:3000"
+      - "${OUTSIDE_XAPP_PORT:-3000}:3000"
     environment:
       - NODE_ENV=production
       - API_URL=${API_URL:-http://xahau-docproof-api:3001/api/}

--- a/xapp/Dockerfile
+++ b/xapp/Dockerfile
@@ -8,6 +8,7 @@ COPY . .
 
 RUN npm install
 
-EXPOSE 3000
+# Disable, needs `--expose` during `docker run` to prevent collisions
+# EXPOSE 3001
 
 CMD ["npm", "run", "dev"]


### PR DESCRIPTION
Allow multi deployment from same host by not explicitly specifying port inside the container, and allowing alternative outside API ports:

Previously because the containers exposed (EXPOSE) from their Dockerfile, it would collide on the host.

By not publishing the exposed port from within the Docker file but leaving it to the docker-compose file the reused ports stay an internal container thing. 

If you want to manually run a single container, the `docker run` commands just needs the `--expose` param during runtime.

Also separated the outside port from the inside port (in the docker-compose config) from ENV.

This works and now powers prod deployment. This can be merged to main (and the other downstream branches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Docker Configuration**
	- Updated port mapping configuration in Docker Compose to use new environment variables for external port definitions
	- Modified Dockerfiles to comment out port exposure instructions
	- Adjusted port handling to prevent potential port collision issues during container deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->